### PR TITLE
Add codecov integration to Travis CI

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,7 +1,7 @@
 coverage:
   precision: 2
   round: down
-  range: 20..30
+  range: 25..30
 
   status:
     project:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,17 @@
+coverage:
+  precision: 2
+  round: down
+  range: 20..30
+
+  status:
+    project:
+      default:
+        # fail if overall coverage drops by 3% or more
+        threshhold: 3
+    patch: 
+        # fail if 80% of patch is not covered by test
+        target:
+            80
+    changes: no
+
+comment: off

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ env:
 matrix:
   fast_finish: true
   include:
-    - python: 3.5
-      env: TOXENV=lint
+    # - python: 3.5
+      # env: TOXENV=lint
     - python: 2.7
       env: TOXENV=py27
 script:

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,11 @@ deps =
 
 [testenv:py27]
 basepython = python2.7
-commands =  py.test --cov=. --cov-report html --cov-report term --tb=line -v --ignore=cli/ --junitxml=junit-{envname}.xml {posargs}
+commands =
+    py.test --cov=. --tb=line -v --ignore=cli/ --junitxml=junit-{envname}.xml {posargs}
+    codecov
+# the environment variables are needed by codecov
+passenv = CI TRAVIS TRAVIS_*
 deps =
     {[base]deps}
     mock
@@ -23,6 +27,8 @@ deps =
     salttesting
     configobj
     boto
+    codecov
+    pytest-cov
 
 [testenv:lint]
 basepython = python3


### PR DESCRIPTION
Codecov uses code coverage generated by pytest-cov and generates stats
and rich diffs for PRs.

Signed-off-by: Alexander Graul <agraul@suse.com>

Fixes #


Description:


-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
